### PR TITLE
Optimize the solver implementation and reduce allocations from ~1.15-1.20MB to ~38KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# SarmFit 0.0.3
+Improved performance by minimizing allocations (#1) @neon-sunset
+
+# SwarmFit 0.0.2
+_Published to NuGet on 2024-09-14_
+* Published to test automated deployment
+
+# SwarmFit 0.0.1
+_Published to NuGet on 2024-09-14_
+* Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # SarmFit 0.0.3
-Improved performance by minimizing allocations (#1) @neon-sunset
+* SwarmFitter: Improved performance by minimizing allocations (#1) @neon-sunset
+* Renamed classes and arguments to favor `parameters` instead of `variables`
+* SwarmFitter: Use a customizable `IRandomNumberGenerator` with a default that maximizes performance
 
 # SwarmFit 0.0.2
 _Published to NuGet on 2024-09-14_

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/swharden/SwarmFit/actions/workflows/ci.yaml/badge.svg)](https://github.com/swharden/SwarmFit/actions/workflows/ci.yaml)
 
-**SwarmFit is a .NET package for fitting curves to X/Y data** points using [particle swarm optimization](https://en.wikipedia.org/wiki/Particle_swarm_optimization). Unlike other gradient decent strategies, finding the derivative of the error function is not required. SwarmFit can be used to calculate best fit curves for arbitrary equations that use any number of variables.
+**SwarmFit is a .NET package for fitting curves to X/Y data** points using [particle swarm optimization](https://en.wikipedia.org/wiki/Particle_swarm_optimization). Unlike other gradient decent strategies, finding the derivative of the error function is not required. SwarmFit can be used to calculate best fit curves for arbitrary equations that use any number of parameters.
 
 ![](dev/fit.gif)
 
@@ -13,19 +13,21 @@
 double[] xs = [1, 2, 3, 4, 5];
 double[] ys = [304, 229, 174, 134, 111];
 
-// define a fit function using any number of variables.
-static double MyFunc(double x, double[] vars)
+// define a fit function using any number of parameters
+static double MyFunc(double x, double[] parameters)
 {
-    // Y = A + B * e^(x*C)
-    return vars[0] + vars[1] * Math.Exp(x * vars[2]);
+	double a = parameters[0];
+	double b = parameters[1];
+	double c = parameters[2];
+    return a + b * Math.Exp(x * c);
 }
 
-// define the minimum and maximum value for each variable
-double[] minVars = [-100, -5000, -10];
-double[] maxVars = [100, 5000, 10];
+// define the minimum and maximum value for each parameter
+double[] paramMins = [-100, -5000, -10];
+double[] paramMaxs = [100, 5000, 10];
 
 // perform the fit
-double[] solution = QuickFit.Solve(xs, ys, MyFunc, minVars, maxVars);
+double[] solution = QuickFit.Solve(xs, ys, MyFunc, minParams, maxParams);
 
 // display the solution
 double a = solution[0];

--- a/src/SwarmFit.Benchmarks/Program.cs
+++ b/src/SwarmFit.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+﻿using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/src/SwarmFit.Benchmarks/Simple.cs
+++ b/src/SwarmFit.Benchmarks/Simple.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+
+namespace SwarmFit.Benchmarks;
+
+[ShortRunJob]
+[MemoryDiagnoser]
+public class Simple
+{
+    [Benchmark]
+    public (double a, double b, double c) SolveDemo()
+    {
+        // data points to fit
+        double[] xs = [1, 2, 3, 4, 5];
+        double[] ys = [304, 229, 174, 134, 111];
+        
+        static double Fit(double x, double[] vars)
+        {
+            // Y = A + B * e^(x*C)
+            return vars[0] + vars[1] * Math.Exp(x * vars[2]);
+        }
+
+        // define the minimum and maximum value for each variable
+        double[] minVars = [-100, -5000, -10];
+        double[] maxVars = [100, 5000, 10];
+
+        // perform the fit
+        double[] solution = QuickFit.Solve(xs, ys, Fit, minVars, maxVars, iterations: 10_000);
+
+        // display the solution
+        double a = solution[0];
+        double b = solution[1];
+        double c = solution[2];
+        return (a, b, c);
+    }
+}

--- a/src/SwarmFit.Benchmarks/Simple.cs
+++ b/src/SwarmFit.Benchmarks/Simple.cs
@@ -24,7 +24,7 @@ public class Simple
         double[] maxVars = [100, 5000, 10];
 
         // perform the fit
-        double[] solution = QuickFit.Solve(xs, ys, Fit, minVars, maxVars, iterations: 10_000);
+        double[] solution = QuickFit.Solve(xs, ys, Fit, minVars, maxVars);
 
         // display the solution
         double a = solution[0];

--- a/src/SwarmFit.Benchmarks/SwarmFit.Benchmarks.csproj
+++ b/src/SwarmFit.Benchmarks/SwarmFit.Benchmarks.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SwarmFit\SwarmFit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SwarmFit.Demo/Form1.cs
+++ b/src/SwarmFit.Demo/Form1.cs
@@ -11,21 +11,21 @@ public partial class Form1 : Form
         btnExp2P.Click += (s, e) =>
         {
             Func<double, double[], double> fitFunc = StandardFunctions.Exponential2P;
-            VariableLimits[] limits = [new(-500, 500), new(-1, 1)];
+            ParameterLimits[] limits = [new(-500, 500), new(-1, 1)];
             Fit(fitFunc, limits);
         };
 
         btnExp3P.Click += (s, e) =>
         {
             Func<double, double[], double> fitFunc = StandardFunctions.Exponential3P;
-            VariableLimits[] limits = [new(-500, 500), new(-1, 1), new(-100, 100)];
+            ParameterLimits[] limits = [new(-500, 500), new(-1, 1), new(-100, 100)];
             Fit(fitFunc, limits);
         };
 
         Load += (s, e) => btnExp2P.PerformClick();
     }
 
-    void Fit(Func<double, double[], double> fitFunc, VariableLimits[] limits)
+    void Fit(Func<double, double[], double> fitFunc, ParameterLimits[] limits)
     {
         double[] vars = limits.Select(x => x.Random(Random.Shared)).ToArray();
         double[] xs = ScottPlot.Generate.RandomSample(10, 0, 10);
@@ -68,7 +68,7 @@ public partial class Form1 : Form
         double fitXMin = formsPlot1.Plot.Axes.Bottom.Min;
         double fitXMax = formsPlot1.Plot.Axes.Bottom.Max;
         double[] fitXs = Generate.Range(fitXMin, fitXMax, (fitXMax - fitXMin) / 100);
-        double[] fitYs = fitXs.Select(x => fitFunc.Invoke(x, solution.Variables)).ToArray();
+        double[] fitYs = fitXs.Select(x => fitFunc.Invoke(x, solution.Parameters)).ToArray();
 
         var sl = formsPlot1.Plot.Add.ScatterLine(fitXs, fitYs);
         sl.LineWidth = 2;

--- a/src/SwarmFit.Demo/SwarmFit.Demo.csproj
+++ b/src/SwarmFit.Demo/SwarmFit.Demo.csproj
@@ -7,6 +7,7 @@
         <UseWindowsForms>true</UseWindowsForms>
         <ImplicitUsings>enable</ImplicitUsings>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
+        <NoWarn>NU1701</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/SwarmFit.Tests/Animation.cs
+++ b/src/SwarmFit.Tests/Animation.cs
@@ -5,6 +5,7 @@ namespace SwarmFit.Tests;
 
 public class Animation
 {
+    [Ignore("only used for creating graphics for the website")]
     [Test]
     public void Test_Fit_Rainbow()
     {
@@ -64,6 +65,7 @@ public class Animation
         Console.WriteLine(solution);
     }
 
+    [Ignore("only used for creating graphics for the website")]
     [Test]
     public void Test_Fit_Animation()
     {

--- a/src/SwarmFit.Tests/Animation.cs
+++ b/src/SwarmFit.Tests/Animation.cs
@@ -18,7 +18,7 @@ public class Animation
             return vars[0] + vars[1] * Math.Exp(x * vars[2]);
         }
 
-        VariableLimits[] limits = [
+        ParameterLimits[] limits = [
             new(0, 500),
             new(0, 2000),
             new (-10, 10)
@@ -29,9 +29,9 @@ public class Animation
         FitSolution solution = fit.Solve();
 
         Plot plot = new();
-        double a = solution.Variables[0];
-        double b = solution.Variables[1];
-        double c = solution.Variables[2];
+        double a = solution.Parameters[0];
+        double b = solution.Parameters[1];
+        double c = solution.Parameters[2];
         string formula = $"Y = {a:N2} + {b:N2} * e^(x * {c:N2})";
         plot.Title(formula);
 
@@ -44,7 +44,7 @@ public class Animation
         plot.Axes.AutoScale();
         plot.Axes.ZoomOut(1.5, 1.5);
         double[] fitXs = Generate.Range(plot.Axes.Bottom.Range.Min, plot.Axes.Bottom.Range.Max, plot.Axes.Bottom.Range.Span / 100);
-        double[] fitYs = fitXs.Select(x => MyFunc(x, solution.Variables)).ToArray();
+        double[] fitYs = fitXs.Select(x => MyFunc(x, solution.Parameters)).ToArray();
 
         if (solution.History is not null)
         {
@@ -53,7 +53,7 @@ public class Animation
             {
                 FitSolution intermediateSolution = solution.History[i];
                 Console.WriteLine(intermediateSolution);
-                double[] tempYs = fitXs.Select(x => MyFunc(x, intermediateSolution.Variables)).ToArray();
+                double[] tempYs = fitXs.Select(x => MyFunc(x, intermediateSolution.Parameters)).ToArray();
                 var tempLine = plot.Add.ScatterLine(fitXs, tempYs);
                 tempLine.Color = cmap.GetColor(i, solution.History.Length).WithAlpha(.5);
                 tempLine.LineWidth = 2;
@@ -78,7 +78,7 @@ public class Animation
             return vars[0] + vars[1] * Math.Exp(x * vars[2]);
         }
 
-        VariableLimits[] limits = [
+        ParameterLimits[] limits = [
             new(0, 500),
             new(0, 2000),
             new (-10, 10)
@@ -114,14 +114,14 @@ public class Animation
 
                 FitSolution intermediateSolution = solution.History[i];
                 Console.WriteLine(intermediateSolution);
-                double[] tempYs = fitXs.Select(x => MyFunc(x, intermediateSolution.Variables)).ToArray();
+                double[] tempYs = fitXs.Select(x => MyFunc(x, intermediateSolution.Parameters)).ToArray();
                 var tempLine = plot.Add.ScatterLine(fitXs, tempYs);
                 tempLine.Color = cmap.GetColor(i, solution.History.Length).WithAlpha(.8);
                 tempLine.LineWidth = 4;
 
-                double a = intermediateSolution.Variables[0];
-                double b = intermediateSolution.Variables[1];
-                double c = intermediateSolution.Variables[2];
+                double a = intermediateSolution.Parameters[0];
+                double b = intermediateSolution.Parameters[1];
+                double c = intermediateSolution.Parameters[2];
                 string formula = $"Y = {a:N2} + {b:N2} * e^(x * {c:N2})";
                 plot.Title(formula);
 

--- a/src/SwarmFit.Tests/KnownSolutions.cs
+++ b/src/SwarmFit.Tests/KnownSolutions.cs
@@ -24,7 +24,7 @@ public class KnownSolutions
         double[] solution = QuickFit.Solve(xs, ys, MyFunc, minVars, maxVars);
 
         solution[0].Should().BeApproximately(40.490, 0.002);
-        solution[1].Should().BeApproximately(2594.155, 0.002);
+        solution[1].Should().BeApproximately(2594.155, 1);
         solution[2].Should().BeApproximately(-0.327, 0.002);
 
         Plotting.PlotFit(xs, ys, MyFunc, solution).SavePng("Test_Fit_Values.png", 400, 300);

--- a/src/SwarmFit.Tests/KnownSolutions.cs
+++ b/src/SwarmFit.Tests/KnownSolutions.cs
@@ -7,20 +7,26 @@ public class KnownSolutions
     [Test]
     public void Test_Fit_Values()
     {
+        // Note: these points aren't from a perfect curve (they contain noise)
         double[] xs = [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
         double[] ys = [304.08994, 229.13878, 173.71886, 135.75499,
                111.096794, 94.25109, 81.55578, 71.30187,
                62.146603, 54.212032, 49.20715, 46.765743];
 
-        static double MyFunc(double x, double[] vars) => vars[0] + vars[1] * Math.Exp(vars[2] * x); // Y = A + B * e^(x*C)
+        // This function represents the equation: Y = A + B * e^(x*C)
+        static double MyFunc(double x, double[] vars) => vars[0] + vars[1] * Math.Exp(vars[2] * x);
 
+        // Define limits for each variable
         double[] minVars = [-100, -5000, -10];
         double[] maxVars = [100, 5000, 10];
 
+        // Find a solution for the best parameters to fit the curve to the data points
         double[] solution = QuickFit.Solve(xs, ys, MyFunc, minVars, maxVars);
 
-        solution[0].Should().BeApproximately(40.673, 0.002);
-        solution[1].Should().BeApproximately(2650.065, 0.002);
-        solution[2].Should().BeApproximately(-0.329, 0.002);
+        solution[0].Should().BeApproximately(40.490, 0.002);
+        solution[1].Should().BeApproximately(2594.155, 0.002);
+        solution[2].Should().BeApproximately(-0.327, 0.002);
+
+        Plotting.PlotFit(xs, ys, MyFunc, solution).SavePng("Test_Fit_Values.png", 400, 300);
     }
 }

--- a/src/SwarmFit.Tests/Plotting.cs
+++ b/src/SwarmFit.Tests/Plotting.cs
@@ -1,0 +1,21 @@
+﻿namespace SwarmFit.Tests;
+
+internal static class Plotting
+{
+    public static ScottPlot.Plot PlotFit(double[] xs, double[] ys, Func<double, double[], double> func, double[] solution)
+    {
+        ScottPlot.Plot plot = new();
+
+        var marks = plot.Add.ScatterPoints(xs, ys);
+        marks.MarkerSize = 10;
+        plot.Axes.AutoScale();
+        
+        var limits = plot.Axes.GetLimits();
+        double[] fitXs = ScottPlot.Generate.Range(limits.Left, limits.Right, limits.HorizontalSpan / 100);
+        double[] fitYs = fitXs.Select(x => func(x, solution)).ToArray();
+        var line = plot.Add.ScatterLine(fitXs, fitYs);
+        line.LineWidth = 2;
+
+        return plot;
+    }
+}

--- a/src/SwarmFit.Tests/Quickstart.cs
+++ b/src/SwarmFit.Tests/Quickstart.cs
@@ -41,11 +41,11 @@ public class Quickstart
                62.146603, 54.212032, 49.20715, 46.765743];
 
         Func<double, double[], double> func = StandardFunctions.Exponential3P;
-        VariableLimits[] limits = [new(-5000, 5000), new(-100, 100), new(-100, 100)];
+        ParameterLimits[] limits = [new(-5000, 5000), new(-100, 100), new(-100, 100)];
         SwarmFitter fitter = new(xs, ys, func, limits);
         FitSolution solution = fitter.Solve(10_000);
 
-        double[] fitYs = xs.Select(x => func.Invoke(x, solution.Variables)).ToArray();
+        double[] fitYs = xs.Select(x => func.Invoke(x, solution.Parameters)).ToArray();
 
         Plot plot = new();
         var data = plot.Add.Markers(xs, ys);
@@ -59,7 +59,7 @@ public class Quickstart
 
         plot.Legend.Alignment = Alignment.UpperRight;
 
-        plot.Title($"Y = {solution.Variables[2]:0.00} + {solution.Variables[0]:0.00} * e^({solution.Variables[1]:0.00} * x)");
+        plot.Title($"Y = {solution.Parameters[2]:0.00} + {solution.Parameters[0]:0.00} * e^({solution.Parameters[1]:0.00} * x)");
         plot.Axes.Title.Label.Bold = false;
 
         var saved = plot.SavePng("test.png", 400, 300);

--- a/src/SwarmFit.Tests/RandomNumberGeneratorTests.cs
+++ b/src/SwarmFit.Tests/RandomNumberGeneratorTests.cs
@@ -1,0 +1,29 @@
+﻿namespace SwarmFit.Tests;
+
+class RandomNumberGeneratorTests
+{
+    [Test]
+    public void Test_SystemRandom_ValuesAreUnique()
+    {
+        // NOTE: a duplicate is found by luck after 66k iterations
+        AssertNoDuplicates(new RandomNumberGenerators.SystemRandom(randomSeed: false), 50_000);
+    }
+
+    [Test]
+    public void Test_XorShift_ValuesAreUnique()
+    {
+        AssertNoDuplicates(new RandomNumberGenerators.XorShift(), 100_000);
+    }
+
+    private static void AssertNoDuplicates(IRandomNumberGenerator RNG, int count)
+    {
+        HashSet<double> seen = [];
+        for (int i = 0; i < count; i++)
+        {
+            double value = RNG.NextDouble();
+            if (seen.Contains(value))
+                throw new InvalidOperationException($"duplicate number found after {i} iterations");
+            seen.Add(value);
+        }
+    }
+}

--- a/src/SwarmFit.sln
+++ b/src/SwarmFit.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SwarmFit.Demo", "SwarmFit.D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SwarmFit.Tests", "SwarmFit.Tests\SwarmFit.Tests.csproj", "{5B93F4D3-B9F2-495A-830E-63CB96A3A699}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SwarmFit.Benchmarks", "SwarmFit.Benchmarks\SwarmFit.Benchmarks.csproj", "{0F1DA296-6DFC-4C07-9172-2EAB50CA6A45}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{5B93F4D3-B9F2-495A-830E-63CB96A3A699}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5B93F4D3-B9F2-495A-830E-63CB96A3A699}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5B93F4D3-B9F2-495A-830E-63CB96A3A699}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F1DA296-6DFC-4C07-9172-2EAB50CA6A45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F1DA296-6DFC-4C07-9172-2EAB50CA6A45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F1DA296-6DFC-4C07-9172-2EAB50CA6A45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F1DA296-6DFC-4C07-9172-2EAB50CA6A45}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SwarmFit/FitSolution.cs
+++ b/src/SwarmFit/FitSolution.cs
@@ -1,8 +1,8 @@
 ﻿namespace SwarmFit;
 
-public class FitSolution(double[] vars, double error, TimeSpan elapsed, int iterations, int particles, FitSolution[]? history = null)
+public class FitSolution(double[] parameters, double error, TimeSpan elapsed, int iterations, int particles, FitSolution[]? history = null)
 {
-    public double[] Variables { get; } = [.. vars];
+    public double[] Parameters { get; } = [.. parameters];
     public double Error { get; } = error;
     public FitSolution[]? History { get; } = history;
     public TimeSpan Elapsed { get; } = elapsed;
@@ -11,7 +11,7 @@ public class FitSolution(double[] vars, double error, TimeSpan elapsed, int iter
 
     public override string ToString()
     {
-        string vars = string.Join(", ", Variables.Select(x => x.ToString()));
-        return $"Solution [{vars}] achieved in {Elapsed.TotalMilliseconds} msec using {Particles} particles and {Iterations} iterations";
+        string parameters = string.Join(", ", Parameters.Select(x => x.ToString()));
+        return $"Solution [{parameters}] achieved in {Elapsed.TotalMilliseconds} msec using {Particles} particles and {Iterations} iterations";
     }
 };

--- a/src/SwarmFit/IRandomNumberGenerator.cs
+++ b/src/SwarmFit/IRandomNumberGenerator.cs
@@ -1,0 +1,9 @@
+﻿namespace SwarmFit;
+
+public interface IRandomNumberGenerator
+{
+    /// <summary>
+    /// Return a random double between 0 and 1
+    /// </summary>
+    public double NextDouble();
+}

--- a/src/SwarmFit/ParameterLimits.cs
+++ b/src/SwarmFit/ParameterLimits.cs
@@ -2,7 +2,7 @@
 
 namespace SwarmFit;
 
-public readonly struct VariableLimits(double min, double max)
+public readonly struct ParameterLimits(double min, double max)
 {
     public double Min { get; } = Math.Min(min, max);
     public double Max { get; } = Math.Max(min, max);

--- a/src/SwarmFit/Particle.cs
+++ b/src/SwarmFit/Particle.cs
@@ -21,7 +21,7 @@ public struct Particle
         BestError = bestErr;
     }
 
-    public readonly void RandomizePositions(Random rand, VariableLimits[] limits)
+    public readonly void RandomizePositions(IRandomNumberGenerator rand, VariableLimits[] limits)
     {
         double[] positions = Positions;
         for (int i = 0; i < positions.Length; i++)

--- a/src/SwarmFit/Particle.cs
+++ b/src/SwarmFit/Particle.cs
@@ -21,7 +21,7 @@ public struct Particle
         BestError = bestErr;
     }
 
-    public readonly void RandomizePositions(IRandomNumberGenerator rand, VariableLimits[] limits)
+    public readonly void RandomizePositions(IRandomNumberGenerator rand, ParameterLimits[] limits)
     {
         double[] positions = Positions;
         for (int i = 0; i < positions.Length; i++)

--- a/src/SwarmFit/Particle.cs
+++ b/src/SwarmFit/Particle.cs
@@ -1,6 +1,6 @@
 ﻿namespace SwarmFit;
 
-public class Particle
+public struct Particle
 {
     public double[] Positions;
     public double[] BestPositions;
@@ -21,12 +21,13 @@ public class Particle
         BestError = bestErr;
     }
 
-    public void RandomizePositions(Random rand, VariableLimits[] limits)
+    public readonly void RandomizePositions(Random rand, VariableLimits[] limits)
     {
-        for (int i = 0; i < Positions.Length; i++)
+        double[] positions = Positions;
+        for (int i = 0; i < positions.Length; i++)
         {
-            Positions[i] = limits[i].Random(rand);
+            positions[i] = limits[i].Random(rand);
         }
-        Positions.CopyTo(BestPositions, 0);
+        positions.AsSpan().CopyTo(BestPositions);
     }
 }

--- a/src/SwarmFit/QuickFit.cs
+++ b/src/SwarmFit/QuickFit.cs
@@ -16,7 +16,7 @@ public static class QuickFit
 
         SwarmFitter fit = new(xs, ys, func, limits)
         {
-            NumParticles = 100
+            NumParticles = particles
         };
 
         return fit.Solve(iterations).Variables;

--- a/src/SwarmFit/QuickFit.cs
+++ b/src/SwarmFit/QuickFit.cs
@@ -10,22 +10,22 @@ public static class QuickFit
     /// <param name="xs">horizontal data values to fit</param>
     /// <param name="ys">vertical data values to fit</param>
     /// <param name="func">a user defined function which calculates Y given X according to a collection of parameters</param>
-    /// <param name="minVars">minimum possible value for each parameter</param>
-    /// <param name="maxVars">maximum possible value for each parameter</param>
+    /// <param name="parameterMins">minimum possible value for each parameter</param>
+    /// <param name="parameterMaxes">maximum possible value for each parameter</param>
     /// <param name="particles">Number of particles to use for fitting</param>
     /// <param name="iterations">Number of iterations to move each particle forward before returning the best solution identified</param>
     /// <returns></returns>
     /// <exception cref="ArgumentException"></exception>
-    public static double[] Solve(double[] xs, double[] ys, Func<double, double[], double> func, double[] minVars, double[] maxVars, int particles = 100, int iterations = 10_000)
+    public static double[] Solve(double[] xs, double[] ys, Func<double, double[], double> func, double[] parameterMins, double[] parameterMaxes, int particles = 100, int iterations = 10_000)
     {
-        if (minVars.Length != maxVars.Length)
+        if (parameterMins.Length != parameterMaxes.Length)
         {
-            throw new ArgumentException($"{nameof(minVars)} and {nameof(maxVars)} must have equal length");
+            throw new ArgumentException($"{nameof(parameterMins)} and {nameof(parameterMaxes)} must have equal length");
         }
 
-        VariableLimits[] limits = Enumerable
-            .Range(0, minVars.Length)
-            .Select(x => new VariableLimits(minVars[x], maxVars[x]))
+        ParameterLimits[] limits = Enumerable
+            .Range(0, parameterMins.Length)
+            .Select(x => new ParameterLimits(parameterMins[x], parameterMaxes[x]))
             .ToArray();
 
         SwarmFitter fit = new(xs, ys, func, limits)
@@ -33,6 +33,6 @@ public static class QuickFit
             NumParticles = particles
         };
 
-        return fit.Solve(iterations).Variables;
+        return fit.Solve(iterations).Parameters;
     }
 }

--- a/src/SwarmFit/QuickFit.cs
+++ b/src/SwarmFit/QuickFit.cs
@@ -2,6 +2,20 @@
 
 public static class QuickFit
 {
+    /// <summary>
+    /// This function provides a simple API for fitting paramaters of a function to find the best for for a collection of X/Y data points.
+    /// The swarm fitter has many configuration options which are not available when calling this function, so advanced users
+    /// are encouraged to instantiate a <see cref="SwarmFitter"/> and interact it with directly to find the ideal solution.
+    /// </summary>
+    /// <param name="xs">horizontal data values to fit</param>
+    /// <param name="ys">vertical data values to fit</param>
+    /// <param name="func">a user defined function which calculates Y given X according to a collection of parameters</param>
+    /// <param name="minVars">minimum possible value for each parameter</param>
+    /// <param name="maxVars">maximum possible value for each parameter</param>
+    /// <param name="particles">Number of particles to use for fitting</param>
+    /// <param name="iterations">Number of iterations to move each particle forward before returning the best solution identified</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
     public static double[] Solve(double[] xs, double[] ys, Func<double, double[], double> func, double[] minVars, double[] maxVars, int particles = 100, int iterations = 10_000)
     {
         if (minVars.Length != maxVars.Length)

--- a/src/SwarmFit/RandomNumberGenerators/CryptoRandom.cs
+++ b/src/SwarmFit/RandomNumberGenerators/CryptoRandom.cs
@@ -1,0 +1,14 @@
+﻿namespace SwarmFit.RandomNumberGenerators;
+
+internal class CruptoRandom : IRandomNumberGenerator
+{
+    private readonly System.Security.Cryptography.RandomNumberGenerator Rand = System.Security.Cryptography.RandomNumberGenerator.Create();
+
+    readonly byte[] bytes = new byte[sizeof(int)];
+
+    public double NextDouble()
+    {
+        Rand.GetBytes(bytes);
+        return BitConverter.ToInt32(bytes, 0) & (int.MaxValue - 1);
+    }
+}

--- a/src/SwarmFit/RandomNumberGenerators/CryptoRandom.cs
+++ b/src/SwarmFit/RandomNumberGenerators/CryptoRandom.cs
@@ -1,6 +1,6 @@
 ﻿namespace SwarmFit.RandomNumberGenerators;
 
-internal class CruptoRandom : IRandomNumberGenerator
+public class CruptoRandom : IRandomNumberGenerator
 {
     private readonly System.Security.Cryptography.RandomNumberGenerator Rand = System.Security.Cryptography.RandomNumberGenerator.Create();
 

--- a/src/SwarmFit/RandomNumberGenerators/SystemRandom.cs
+++ b/src/SwarmFit/RandomNumberGenerators/SystemRandom.cs
@@ -1,0 +1,19 @@
+﻿namespace SwarmFit.RandomNumberGenerators;
+
+internal class SystemRandom(bool randomSeed = false) : IRandomNumberGenerator
+{
+    private readonly Random Rand = new(randomSeed ? GetRandomSeed() : 0);
+
+    private static int GetRandomSeed()
+    {
+        var RNG = System.Security.Cryptography.RandomNumberGenerator.Create();
+        byte[] data = new byte[sizeof(int)];
+        RNG.GetBytes(data);
+        return BitConverter.ToInt32(data, 0) & (int.MaxValue - 1);
+    }
+
+    public double NextDouble()
+    {
+        return Rand.NextDouble();
+    }
+}

--- a/src/SwarmFit/RandomNumberGenerators/SystemRandom.cs
+++ b/src/SwarmFit/RandomNumberGenerators/SystemRandom.cs
@@ -6,7 +6,7 @@ public class SystemRandom(bool randomSeed = false) : IRandomNumberGenerator
 
     private static int GetRandomSeed()
     {
-        var RNG = System.Security.Cryptography.RandomNumberGenerator.Create();
+        System.Security.Cryptography.RandomNumberGenerator RNG = System.Security.Cryptography.RandomNumberGenerator.Create();
         byte[] data = new byte[sizeof(int)];
         RNG.GetBytes(data);
         return BitConverter.ToInt32(data, 0) & (int.MaxValue - 1);

--- a/src/SwarmFit/RandomNumberGenerators/SystemRandom.cs
+++ b/src/SwarmFit/RandomNumberGenerators/SystemRandom.cs
@@ -1,6 +1,6 @@
 ﻿namespace SwarmFit.RandomNumberGenerators;
 
-internal class SystemRandom(bool randomSeed = false) : IRandomNumberGenerator
+public class SystemRandom(bool randomSeed = false) : IRandomNumberGenerator
 {
     private readonly Random Rand = new(randomSeed ? GetRandomSeed() : 0);
 

--- a/src/SwarmFit/RandomNumberGenerators/XorShift.cs
+++ b/src/SwarmFit/RandomNumberGenerators/XorShift.cs
@@ -1,10 +1,10 @@
 ﻿namespace SwarmFit.RandomNumberGenerators;
 
+// See: https://en.wikipedia.org/wiki/Xorshift
+// Note: 2463534242 in binary is 10010010110101101000110010100010 which has a nice balance of 1s and 0s
 public class XorShift(uint seed = 2463534242) : IRandomNumberGenerator
 {
-    // note: 2463534242 in binary is 10010010110101101000110010100010 which has a nice balance of 1s and 0s
-
-    private uint Rand = seed != 0 ? seed : throw new InvalidOperationException("Don't seed me with a 0 or you'll always get 0 back");
+    private uint Rand = seed;
 
     public uint Next()
     {

--- a/src/SwarmFit/RandomNumberGenerators/XorShift.cs
+++ b/src/SwarmFit/RandomNumberGenerators/XorShift.cs
@@ -1,0 +1,19 @@
+﻿namespace SwarmFit.RandomNumberGenerators;
+
+public class XorShift(uint seed = 0) : IRandomNumberGenerator
+{
+    private uint Rand = seed;
+
+    public uint Next()
+    {
+        Rand ^= Rand << 13;
+        Rand ^= Rand >> 17;
+        Rand ^= Rand << 5;
+        return Rand;
+    }
+
+    public double NextDouble()
+    {
+        return (double)Next() / uint.MaxValue;
+    }
+}

--- a/src/SwarmFit/RandomNumberGenerators/XorShift.cs
+++ b/src/SwarmFit/RandomNumberGenerators/XorShift.cs
@@ -1,8 +1,10 @@
 ﻿namespace SwarmFit.RandomNumberGenerators;
 
-public class XorShift(uint seed = 0) : IRandomNumberGenerator
+public class XorShift(uint seed = 2463534242) : IRandomNumberGenerator
 {
-    private uint Rand = seed;
+    // note: 2463534242 in binary is 10010010110101101000110010100010 which has a nice balance of 1s and 0s
+
+    private uint Rand = seed != 0 ? seed : throw new InvalidOperationException("Don't seed me with a 0 or you'll always get 0 back");
 
     public uint Next()
     {

--- a/src/SwarmFit/StandardFunctions.cs
+++ b/src/SwarmFit/StandardFunctions.cs
@@ -5,18 +5,18 @@ public static class StandardFunctions
     /// <summary>
     /// A * e^(B*x)
     /// </summary>
-    public static double Exponential2P(double x, double[] vars)
+    public static double Exponential2P(double x, double[] parameters)
     {
-        if (vars.Length != 2) throw new ArgumentException($"{nameof(vars)} length must equal 2");
-        return vars[0] * Math.Exp(vars[1] * x);
+        if (parameters.Length != 2) throw new ArgumentException($"{nameof(parameters)} length must equal 2");
+        return parameters[0] * Math.Exp(parameters[1] * x);
     }
 
     /// <summary>
     /// A * e^(B*x) + C
     /// </summary>
-    public static double Exponential3P(double x, double[] vars)
+    public static double Exponential3P(double x, double[] parameters)
     {
-        if (vars.Length != 3) throw new ArgumentException($"{nameof(vars)} length must equal 3");
-        return vars[0] * Math.Exp(vars[1] * x) + vars[2];
+        if (parameters.Length != 3) throw new ArgumentException($"{nameof(parameters)} length must equal 3");
+        return parameters[0] * Math.Exp(parameters[1] * x) + parameters[2];
     }
 }

--- a/src/SwarmFit/SwarmFit.csproj
+++ b/src/SwarmFit/SwarmFit.csproj
@@ -38,7 +38,6 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="System.Buffers" Version="4.5.1" />
         <PackageReference Include="System.Memory" Version="4.5.5" />
     </ItemGroup>
 

--- a/src/SwarmFit/SwarmFit.csproj
+++ b/src/SwarmFit/SwarmFit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <langversion>12</langversion>
@@ -35,6 +35,11 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="System.Buffers" Version="4.5.1" />
+        <PackageReference Include="System.Memory" Version="4.5.5" />
     </ItemGroup>
 
 </Project>

--- a/src/SwarmFit/SwarmFitter.cs
+++ b/src/SwarmFit/SwarmFitter.cs
@@ -4,6 +4,7 @@
  */
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace SwarmFit;
 
@@ -14,7 +15,7 @@ public class SwarmFitter
     public Func<double, double[], double> Function { get; }
     VariableLimits[] VarLimits { get; }
 
-    public Random Rand = new(0); // TODO: make this settable
+    public Random Rand = new(); // TODO: make this settable
     public double VelocityRandomness = 0.1;
     public double InertiaWeight = 0.729;
     public double LocalWeight = 1.49445;
@@ -36,16 +37,20 @@ public class SwarmFitter
         VarLimits = limits;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     double GetError(double[] vars)
     {
         double error = 0;
+        double[] xs = Xs;
+        double[] ys = Ys;
+        bool squareError = SquareError;
 
-        for (int i = 0; i < Xs.Length; i++)
+        for (int i = 0; i < xs.Length; i++)
         {
-            double predictedY = GetY(Xs[i], vars);
-            double actualY = Ys[i];
+            double predictedY = GetY(xs[i], vars);
+            double actualY = ys[i];
             double diff = Math.Abs(predictedY - actualY);
-            error += SquareError ? diff * diff : diff;
+            error += squareError ? diff * diff : diff;
         }
 
         return error;
@@ -57,88 +62,90 @@ public class SwarmFitter
     public FitSolution Solve(int iterations = 1000)
     {
         Stopwatch sw = Stopwatch.StartNew();
+        Random rand = Rand;
 
         double[] bestGlobalPositions = new double[VariableCount];
         double bestGlobalError = double.MaxValue;
 
-        Particle[] particles = new Particle[NumParticles];
-        List<FitSolution> intermediateSolutions = [];
+        Span<Particle> particles = new Particle[NumParticles];
+        List<FitSolution>? intermediateSolutions = StoreIntermediateSolutions ? [] : null;
 
         for (int i = 0; i < particles.Length; i++)
         {
-            double[] randomPositions = VarLimits.Select(x => x.Random(Rand)).ToArray();
+            double[] randomPositions = VarLimits.Select(x => x.Random(rand)).ToArray();
             double error = GetError(randomPositions);
-            double[] randomVelocities = VarLimits.Select(x => x.Random(Rand) * VelocityRandomness).ToArray();
+            double[] randomVelocities = VarLimits.Select(x => x.Random(rand) * VelocityRandomness).ToArray();
             particles[i] = new Particle(randomPositions, error, randomVelocities, randomPositions, error);
 
             if (particles[i].Error < bestGlobalError)
             {
                 bestGlobalError = particles[i].Error;
-                particles[i].Positions.CopyTo(bestGlobalPositions, 0);
+                particles[i].Positions.AsSpan().CopyTo(bestGlobalPositions);
             }
         }
 
-        if (StoreIntermediateSolutions)
-        {
-            intermediateSolutions.Add(new(bestGlobalPositions, bestGlobalError, sw.Elapsed, 0, particles.Length));
-        }
+        intermediateSolutions?.Add(new(bestGlobalPositions, bestGlobalError, sw.Elapsed, 0, particles.Length));
+
+        double[] newVelocity = new double[VariableCount];
+        double[] newPosition = new double[VariableCount];
 
         for (int iteration = 1; iteration <= iterations; iteration++)
         {
-            double[] newVelocity = new double[VariableCount];
-            double[] newPosition = new double[VariableCount];
-
-            foreach (Particle particle in particles)
+            foreach (ref Particle particle in particles)
             {
-                for (int j = 0; j < particle.Velocities.Length; j++)
+                double[] positions = particle.Positions;
+                double[] bestPositions = particle.BestPositions;
+                double[] velocities = particle.Velocities;
+
+                for (int j = 0; j < velocities.Length; j++)
                 {
-                    double inertia = InertiaWeight * particle.Velocities[j];
-                    double local = LocalWeight * Rand.NextDouble() * (particle.BestPositions[j] - particle.Positions[j]);
-                    double global = GlobalWeight * Rand.NextDouble() * (bestGlobalPositions[j] - particle.Positions[j]);
+                    double inertia = InertiaWeight * velocities[j];
+                    double local = LocalWeight * rand.NextDouble() * (bestPositions[j] - positions[j]);
+                    double global = GlobalWeight * rand.NextDouble() * (bestGlobalPositions[j] - positions[j]);
                     newVelocity[j] = inertia + local + global;
                 }
 
-                newVelocity.CopyTo(particle.Velocities, 0);
+                newVelocity.AsSpan().CopyTo(velocities);
 
-                for (int j = 0; j < particle.Positions.Length; j++)
+                for (int j = 0; j < positions.Length; j++)
                 {
-                    newPosition[j] = particle.Positions[j] + newVelocity[j];
+                    newPosition[j] = positions[j] + newVelocity[j];
                     newPosition[j] = VarLimits[j].Clamp(newPosition[j]);
                 }
-                newPosition.CopyTo(particle.Positions, 0);
+                newPosition.AsSpan().CopyTo(positions);
 
                 double newError = GetError(newPosition);
                 particle.Error = newError;
 
                 if (newError < particle.BestError)
                 {
-                    newPosition.CopyTo(particle.BestPositions, 0);
+                    newPosition.AsSpan().CopyTo(bestPositions);
                     particle.BestError = newError;
                 }
 
                 if (newError < bestGlobalError)
                 {
-                    newPosition.CopyTo(bestGlobalPositions, 0);
+                    newPosition.AsSpan().CopyTo(bestGlobalPositions);
                     bestGlobalError = newError;
-                    intermediateSolutions.Add(new(bestGlobalPositions, bestGlobalError, sw.Elapsed, iteration, particles.Length));
+                    intermediateSolutions?.Add(new(bestGlobalPositions, bestGlobalError, sw.Elapsed, iteration, particles.Length));
                 }
 
-                if (Rand.NextDouble() < probDeath)
+                if (rand.NextDouble() < probDeath)
                 {
-                    particle.RandomizePositions(Rand, VarLimits);
+                    particle.RandomizePositions(rand, VarLimits);
                     particle.Error = GetError(particle.Positions);
                     particle.BestError = particle.Error;
 
                     if (particle.Error < bestGlobalError)
                     {
                         bestGlobalError = particle.Error;
-                        particle.Positions.CopyTo(bestGlobalPositions, 0);
-                        intermediateSolutions.Add(new(bestGlobalPositions, bestGlobalError, sw.Elapsed, iteration, particles.Length));
+                        positions.AsSpan().CopyTo(bestGlobalPositions);
+                        intermediateSolutions?.Add(new(bestGlobalPositions, bestGlobalError, sw.Elapsed, iteration, particles.Length));
                     }
                 }
             }
         }
 
-        return new FitSolution(bestGlobalPositions, bestGlobalError, sw.Elapsed, iterations, particles.Length, intermediateSolutions.Any() ? [.. intermediateSolutions] : null);
+        return new FitSolution(bestGlobalPositions, bestGlobalError, sw.Elapsed, iterations, particles.Length, intermediateSolutions?.ToArray());
     }
 }

--- a/src/SwarmFit/SwarmFitter.cs
+++ b/src/SwarmFit/SwarmFitter.cs
@@ -15,7 +15,9 @@ public class SwarmFitter
     public Func<double, double[], double> Function { get; }
     VariableLimits[] VarLimits { get; }
 
-    public Random Rand = new(); // TODO: make this settable
+    // Consider using seed-less constructor which picks faster implementation
+    // or providing a custom RNG - this is the hottest part of the algorithm.
+    public Random Rand = new(0); // TODO: make this settable
     public double VelocityRandomness = 0.1;
     public double InertiaWeight = 0.729;
     public double LocalWeight = 1.49445;

--- a/src/SwarmFit/VariableLimits.cs
+++ b/src/SwarmFit/VariableLimits.cs
@@ -1,4 +1,6 @@
-﻿namespace SwarmFit;
+﻿using System.Runtime.CompilerServices;
+
+namespace SwarmFit;
 
 public readonly struct VariableLimits(double min, double max)
 {
@@ -8,6 +10,7 @@ public readonly struct VariableLimits(double min, double max)
     public double Span => Max - Min;
     public double Random(Random rand) => Span * rand.NextDouble() + Min;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public double Clamp(double value)
     {
         if (value < Min) return Min;

--- a/src/SwarmFit/VariableLimits.cs
+++ b/src/SwarmFit/VariableLimits.cs
@@ -8,6 +8,7 @@ public readonly struct VariableLimits(double min, double max)
     public double Max { get; } = Math.Max(min, max);
     public double Mid => (Min + Max) / 2;
     public double Span => Max - Min;
+    public double Random(IRandomNumberGenerator rand) => Span * rand.NextDouble() + Min;
     public double Random(Random rand) => Span * rand.NextDouble() + Min;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/SwarmFit/nuget-readme.md
+++ b/src/SwarmFit/nuget-readme.md
@@ -1,6 +1,6 @@
 # SwarmFit
 
-**SwarmFit is a .NET package for fitting curves to X/Y data** points using particle swarm optimization. Unlike other gradient decent strategies, finding the derivative of the error function is not required. SwarmFit can be used to calculate best fit curves for arbitrary equations that use any number of variables.
+**SwarmFit is a .NET package for fitting curves to X/Y data** points using particle swarm optimization. Unlike other gradient decent strategies, finding the derivative of the error function is not required. SwarmFit can be used to calculate best fit curves for arbitrary equations that use any number of parameters.
 
 ![](https://raw.githubusercontent.com/swharden/SwarmFit/main/dev/fit.gif)
 
@@ -11,19 +11,21 @@
 double[] xs = [1, 2, 3, 4, 5];
 double[] ys = [304, 229, 174, 134, 111];
 
-// define a fit function using any number of variables.
-static double MyFunc(double x, double[] vars)
+// define a fit function using any number of parameters
+static double MyFunc(double x, double[] parameters)
 {
-    // Y = A + B * e^(x*C)
-    return vars[0] + vars[1] * Math.Exp(x * vars[2]);
+	double a = parameters[0];
+	double b = parameters[1];
+	double c = parameters[2];
+    return a + b * Math.Exp(x * c);
 }
 
-// define the minimum and maximum value for each variable
-double[] minVars = [-100, -5000, -10];
-double[] maxVars = [100, 5000, 10];
+// define the minimum and maximum value for each parameter
+double[] paramMins = [-100, -5000, -10];
+double[] paramMaxs = [100, 5000, 10];
 
 // perform the fit
-double[] solution = QuickFit.Solve(xs, ys, MyFunc, minVars, maxVars);
+double[] solution = QuickFit.Solve(xs, ys, MyFunc, minParams, maxParams);
 
 // display the solution
 double a = solution[0];


### PR DESCRIPTION
### Description

A friend of mine linked me this project, and I took a quick stab at optimizing the implementation to avoid unnecessary allocations that would significantly impact end user applications. Such GC impact is usually not well seen on microbenchmarks like the ones ran by BenchmarkDotNet since it invokes GC in-between the runs. Once I get to my Windows PC, I plan to see how this impacts the WinForms demo but it should be an improvement regardless.

I have changed the project to be multi-targeted in order for the collection expressions (like `[..items]`) to be able to use more efficient underlying APIs - TFM affects the Roslyn output, and NS2.0 is a really conservative target that prevents it from using any new API which is why it is recommended to provide both new and compat TFM package versions, if you want to do the latter in the first place. Adding `System.Memory` polyfill package for `Span<T>` allowed using `span.CopyTo(dest)` instead of Array's own `.CopyTo(dest, idx)` - the reason for this is array's one incurs the cost of C#'s original sin - array covariance and checks associated with it. Because spans do not allow this, their version of CopyTo is a simple length comparison and immediate call to the underlying CoreLib's `Memmove` implementation, something that array methods take extra steps to call into.

There are other small changes like ensuring that array references are not re-read per iteration from solver class fields, and are properly hoisted to locals to enable .NET to elide bound checks against them and clone the loops to provide bounds-check-less fast paths where the length bound cannot be proven. It's part of the reason why `Particle` is changed to be a struct and addressed via `ref` instead, another part is it improves data locality.

Last but not least, the biggest bottleneck here is the default *and* legacy `Random` implementation. When `Random` instance is constructed without a seed, a newer Xoshiro implementation is used which is significantly faster and has stable execution time (whatever happens with legacy one makes the results regress as they continue to get executed, and tends to cause massive bimodal gap between run latencies on Windows, but that's not just with Random, only that it exacerbates it). Unfortunately, it results in non-deterministic results with larger output variance, which makes tests crash unless the result precision tolerance is significantly relaxed, so I have only left the comment to consider this change and included reference numbers below.

In order to speed-up the algorithm further, it may be worth exploring custom RNG implementations that produce either more favourable distribution of values to this algorithm, or are faster, not being subject to the exact output the default Random with seed is limited to due to backwards compatibility considerations.

### Numbers

Environment
```
// * Summary *

BenchmarkDotNet v0.14.0, macOS Sequoia 15.0 (24A335) [Darwin 24.0.0]
Apple M1 Pro, 1 CPU, 8 logical and 8 physical cores
.NET SDK 9.0.100-rc.1.24414.7
  [Host]     : .NET 8.0.8 (8.0.824.36612), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.8 (8.0.824.36612), Arm64 RyuJIT AdvSIMD
```

Before the change

| Method    | Mean     | Error   | StdDev  | Gen0     | Allocated |
|---------- |---------:|--------:|--------:|---------:|----------:|
| SolveDemo | 104.7 ms | 0.20 ms | 0.18 ms | 166.6667 |   1.15 MB |

Note: starts at ~90ms and then regresses

After the change (with seedless but non-deterministic Random impl. provided by `new()`, makes tests unhappy with much more significant output variation)

| Method    | Mean     | Error    | StdDev   | Allocated |
|---------- |---------:|---------:|---------:|----------:|
| SolveDemo | 65.51 ms | 0.139 ms | 0.123 ms |  37.93 KB |

After the change (with current Random impl. provided by new(0))


| Method    | Mean     | Error    | StdDev   | Allocated |
|---------- |---------:|---------:|---------:|----------:|
| SolveDemo | 98.67 ms | 0.158 ms | 0.132 ms |  38.17 KB |

Note: starts at ~77ms and then regresses